### PR TITLE
I changed it because if we set no parameters than the click button re…

### DIFF
--- a/android-file-chooser/src/main/java/ir/sohreco/androidfilechooser/FileChooserDialog.java
+++ b/android-file-chooser/src/main/java/ir/sohreco/androidfilechooser/FileChooserDialog.java
@@ -117,7 +117,6 @@ public class FileChooserDialog extends AppCompatDialogFragment implements ItemHo
          */
         public Builder setInitialDirectory(File initialDirectory) {
             if (initialDirectory == null)
-                
                 throw new NullPointerException("initialDirectory can't be null.");
 
             if (!initialDirectory.exists())

--- a/android-file-chooser/src/main/java/ir/sohreco/androidfilechooser/FileChooserDialog.java
+++ b/android-file-chooser/src/main/java/ir/sohreco/androidfilechooser/FileChooserDialog.java
@@ -117,6 +117,7 @@ public class FileChooserDialog extends AppCompatDialogFragment implements ItemHo
          */
         public Builder setInitialDirectory(File initialDirectory) {
             if (initialDirectory == null)
+                
                 throw new NullPointerException("initialDirectory can't be null.");
 
             if (!initialDirectory.exists())
@@ -290,7 +291,7 @@ public class FileChooserDialog extends AppCompatDialogFragment implements ItemHo
         rvItems.setLayoutManager(new LinearLayoutManager(getActivity()));
         rvItems.setAdapter(itemsAdapter);
 
-        loadItems(initialDirectory != null ? initialDirectory : Environment.getExternalStorageDirectory().getPath());
+        loadItems(initialDirectory != null ? initialDirectory : Environment.getRootDirectory().getParent());
 
         return view;
     }


### PR DESCRIPTION
…sult in crash on android 6 because sdcard permission are not given

I changed it because if we set no parameters than the click button result in crash on android 6 because sdcard permission are not given

So better to use root directory instead of externalsdcard on android 6 and up so no crashes comes when external storage permission is not given much safe